### PR TITLE
Fix deleted wall galleries

### DIFF
--- a/core/gallery/functions.php
+++ b/core/gallery/functions.php
@@ -292,10 +292,9 @@ function mpp_delete_wall_gallery_id( $args  ) {
 	if ( function_exists( $func_name ) )
 		call_user_func( $func_name,  $component_id, $media_type, $gallery_id  );
 
-	return apply_filters( 'mpp_delete_wall_gallery_id', $id, $component_id, $component, $media_type );
-	
-	
-	
+	// this filter isn't used and not sure what it would be used *for* ~cr
+	// return apply_filters( 'mpp_delete_wall_gallery_id', $user_id, $component_id, $component, $media_type );
+
 }
 
 /**

--- a/core/gallery/functions.php
+++ b/core/gallery/functions.php
@@ -290,7 +290,7 @@ function mpp_delete_wall_gallery_id( $args  ) {
 	$func_name	 = "mpp_delete_{$component}_wall_gallery_id";
 
 	if ( function_exists( $func_name ) )
-		$id			 = call_user_func( $func_name,  $component_id, $media_type, $gallery_id  );
+		call_user_func( $func_name,  $component_id, $media_type, $gallery_id  );
 
 	return apply_filters( 'mpp_delete_wall_gallery_id', $id, $component_id, $component, $media_type );
 	


### PR DESCRIPTION
If a wall gallery is deleted, the usermeta for that gallery is never deleted with it. Tracked it down to the `mpp_delete_wall_gallery_id` function which saves the result of `mpp_delete_{$component}_wall_gallery_id` to a variable and then runs a filter on it. Except I don't think this is done correctly and, anyway, the filter is never being used. Rewrote the code to simply run the function, so the appropriate delete_{component}_ gallery function executes and the originating `mpp_delete_gallery` function finishes properly.
