### PR TITLE
Enable Multi File Uploads on Mobile

### DIFF
--- a/assets/mpp-assets-loader.php
+++ b/assets/mpp-assets-loader.php
@@ -234,7 +234,7 @@ class MPP_Assets_Loader {
 		// Multi-file uploading doesn't currently work in iOS Safari,
 		// single-file allows the built-in camera to be used as source for images.
 		if ( wp_is_mobile() ) {
-			$defaults['multi_selection'] = false;
+			$defaults['multi_selection'] = true;
 		}
 
 		$defaults = apply_filters( 'mpp_upload_default_settings', $defaults );


### PR DESCRIPTION
This has now been fixed in the latest versions of chrome and safari. Verified and tested on iOS and Android for uploading to activity and personal galleries in BuddyPress