### PR TITLE
Fix BuddyPress group URL deprecation and PHP 8.2 dynamic property warning

### DIFF
--- a/core/gallery/mpp-gallery-link-template.php
+++ b/core/gallery/mpp-gallery-link-template.php
@@ -9,6 +9,42 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 
 /**
+ * Get group URL with BuddyPress compatibility.
+ *
+ * @param int|object $group Group id or object.
+ *
+ * @return string
+ */
+function mpp_get_group_url( $group = 0 ) {
+
+	if ( empty( $group ) ) {
+		return '';
+	}
+
+	if ( is_numeric( $group ) ) {
+		if ( ! class_exists( 'BP_Groups_Group' ) ) {
+			return '';
+		}
+		$group = new BP_Groups_Group( $group );
+	}
+
+	// Ensure we have a real group object with a valid id.
+	if ( ! is_object( $group ) || empty( $group->id ) ) {
+		return '';
+	}
+
+	if ( function_exists( 'bp_get_group_url' ) ) {
+		return bp_get_group_url( $group );
+	}
+
+	if ( function_exists( 'bp_get_group_permalink' ) ) {
+		return bp_get_group_permalink( $group );
+	}
+
+	return '';
+}
+
+/**
  * Get the base url for the component gallery home page
  * e.g http://site.com/members/user-name/gallery //without any trailing slash
  *
@@ -25,13 +61,10 @@ function mpp_get_gallery_base_url( $component, $component_id ) {
 
 	if ( 'members' === $component ) {
 		$base_url = trailingslashit( mpp_get_user_url( $component_id ) ) . MPP_GALLERY_SLUG;
-	} elseif ( 'groups' === $component && ( function_exists( 'bp_get_group_url' ) || function_exists( 'bp_get_group_permalink' ) ) ) {
-		$group = new BP_Groups_Group( $component_id );
-
-		if ( function_exists( 'bp_get_group_url' ) ) {
-			$base_url = trailingslashit( bp_get_group_url( $group ) ) . MPP_GALLERY_SLUG;
-		} else {
-			$base_url = trailingslashit( bp_get_group_permalink( $group ) ) . MPP_GALLERY_SLUG;
+	} elseif ( 'groups' === $component ) {
+		$group_url = mpp_get_group_url( $component_id );
+		if ( $group_url ) {
+			$base_url = trailingslashit( $group_url ) . MPP_GALLERY_SLUG;
 		}
 	}
 	// for admin new/edit gallery, specially new gallery.

--- a/core/gallery/mpp-gallery-link-template.php
+++ b/core/gallery/mpp-gallery-link-template.php
@@ -25,8 +25,14 @@ function mpp_get_gallery_base_url( $component, $component_id ) {
 
 	if ( 'members' === $component ) {
 		$base_url = trailingslashit( mpp_get_user_url( $component_id ) ) . MPP_GALLERY_SLUG;
-	} elseif ( 'groups' === $component && function_exists( 'bp_get_group_permalink' ) ) {
-		$base_url = trailingslashit( bp_get_group_permalink( new BP_Groups_Group( $component_id ) ) ) . MPP_GALLERY_SLUG;
+	} elseif ( 'groups' === $component && ( function_exists( 'bp_get_group_url' ) || function_exists( 'bp_get_group_permalink' ) ) ) {
+		$group = new BP_Groups_Group( $component_id );
+
+		if ( function_exists( 'bp_get_group_url' ) ) {
+			$base_url = trailingslashit( bp_get_group_url( $group ) ) . MPP_GALLERY_SLUG;
+		} else {
+			$base_url = trailingslashit( bp_get_group_permalink( $group ) ) . MPP_GALLERY_SLUG;
+		}
 	}
 	// for admin new/edit gallery, specially new gallery.
 	if ( ! $base_url && ( empty( $component ) || empty( $component_id ) ) ) {

--- a/modules/buddypress/activity/mpp-activity-functions.php
+++ b/modules/buddypress/activity/mpp-activity-functions.php
@@ -926,7 +926,12 @@ function mpp_activity_post_group_update( $args = array() ) {
 	}
 
 	// Record this in activity streams.
-	$activity_action  = sprintf( __( '%1$s posted an update in the group %2$s', 'mediapress' ), bp_core_get_userlink( $user_id ), '<a href="' . esc_url( bp_get_group_permalink( $bp->groups->current_group ) ) . '">' . esc_attr( $bp->groups->current_group->name ) . '</a>' );
+	if ( function_exists( 'bp_get_group_url' ) ) {
+		$group_url = bp_get_group_url( $bp->groups->current_group );
+	} else {
+		$group_url = bp_get_group_permalink( $bp->groups->current_group );
+	}
+	$activity_action  = sprintf( __( '%1$s posted an update in the group %2$s', 'mediapress' ), bp_core_get_userlink( $user_id ), '<a href="' . esc_url( $group_url ) . '">' . esc_attr( $bp->groups->current_group->name ) . '</a>' );
 	$activity_content = $r['content'];
 
 	/**

--- a/modules/buddypress/activity/mpp-activity-functions.php
+++ b/modules/buddypress/activity/mpp-activity-functions.php
@@ -926,11 +926,7 @@ function mpp_activity_post_group_update( $args = array() ) {
 	}
 
 	// Record this in activity streams.
-	if ( function_exists( 'bp_get_group_url' ) ) {
-		$group_url = bp_get_group_url( $bp->groups->current_group );
-	} else {
-		$group_url = bp_get_group_permalink( $bp->groups->current_group );
-	}
+	$group_url = mpp_get_group_url( $bp->groups->current_group );
 	$activity_action  = sprintf( __( '%1$s posted an update in the group %2$s', 'mediapress' ), bp_core_get_userlink( $user_id ), '<a href="' . esc_url( $group_url ) . '">' . esc_attr( $bp->groups->current_group->name ) . '</a>' );
 	$activity_content = $r['content'];
 

--- a/modules/buddypress/groups/mpp-bp-groups-hooks.php
+++ b/modules/buddypress/groups/mpp-bp-groups-hooks.php
@@ -81,8 +81,13 @@ function mpp_group_form_uploaded_activity_action( $action, $activity, $media_id,
 	$group_id = $activity->item_id;
 
 	$group = new BP_Groups_Group( $group_id );
+	if ( function_exists( 'bp_get_group_url' ) ) {
+		$group_url = bp_get_group_url( $group );
+	} else {
+		$group_url = bp_get_group_permalink( $group );
+	}
 
-	$group_link = sprintf( "<a href='%s'>%s</a>", bp_get_group_permalink( $group ), bp_get_group_name( $group ) );
+	$group_link = sprintf( "<a href='%s'>%s</a>", $group_url, bp_get_group_name( $group ) );
 	$action     = sprintf( __( '%s uploaded %d new %s to %s', 'mediapress' ), mpp_get_user_link( $activity->user_id ), $media_count, $type, $group_link );
 
 	return $action;

--- a/modules/buddypress/groups/mpp-bp-groups-hooks.php
+++ b/modules/buddypress/groups/mpp-bp-groups-hooks.php
@@ -81,11 +81,7 @@ function mpp_group_form_uploaded_activity_action( $action, $activity, $media_id,
 	$group_id = $activity->item_id;
 
 	$group = new BP_Groups_Group( $group_id );
-	if ( function_exists( 'bp_get_group_url' ) ) {
-		$group_url = bp_get_group_url( $group );
-	} else {
-		$group_url = bp_get_group_permalink( $group );
-	}
+	$group_url = mpp_get_group_url( $group );
 
 	$group_link = sprintf( "<a href='%s'>%s</a>", $group_url, bp_get_group_name( $group ) );
 	$action     = sprintf( __( '%s uploaded %d new %s to %s', 'mediapress' ), mpp_get_user_link( $activity->user_id ), $media_count, $type, $group_link );

--- a/modules/buddypress/mpp-bp-component.php
+++ b/modules/buddypress/mpp-bp-component.php
@@ -24,6 +24,20 @@ class MPP_BuddyPress_Component extends BP_Component {
 	private static $instance;
 
 	/**
+	 * Forbidden names for BuddyPress routes.
+	 *
+	 * @var array
+	 */
+	public $forbidden_names = array();
+
+	/**
+	 * Valid gallery status keys.
+	 *
+	 * @var array
+	 */
+	public $valid_status = array();
+
+	/**
 	 * Get the singleton instance
 	 *
 	 * @return MPP_BuddyPress_Component


### PR DESCRIPTION
## Summary
This PR includes two compatibility fixes:

1. Replaces deprecated BuddyPress group permalink usage by preferring `bp_get_group_url()` with fallback to `bp_get_group_permalink()` for backward compatibility.
2. Declares `forbidden_names` and `valid_status` properties on `MPP_BuddyPress_Component` to avoid PHP 8.2 dynamic property warnings.

## Files changed
- `modules/buddypress/mpp-bp-component.php`
- `core/gallery/mpp-gallery-link-template.php`
- `modules/buddypress/groups/mpp-bp-groups-hooks.php`
- `modules/buddypress/activity/mpp-activity-functions.php`

## Compatibility
- Keeps backward compatibility with older BuddyPress via fallback checks.
- No function signatures changed.
- Existing escaping/output behavior preserved.

## Validation
- PHP lint checks passed for all modified files.
